### PR TITLE
update common service to v0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@EssexManagement/clinical-trial-matching-service": {
-      "version": "0.2.4",
-      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.4/d744720295a0af49646c733716167eecdf730a4c",
-      "integrity": "sha512-F1Q4NMu6V60GLYx0dAYQ/kXRV2dfuZ5AodAr6e3ST6kCXZqg0MzcTzLuwnsJq06ZrSF9U6TKhqu8NBP/TDf4cQ==",
+      "version": "0.2.5",
+      "resolved": "https://npm.pkg.github.com/download/@EssexManagement/clinical-trial-matching-service/0.2.5/7f10764a1bb4817f2775909b73ed5812e581cb6d",
+      "integrity": "sha512-5qkhARtu5pV+5u+IT63bTNlQBgU2wKvmJiKvYmrCy6cTKgV3tWxwWRKklmjau723Y4aYPheuUEdMwD1WOgpDhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",


### PR DESCRIPTION
- includes updates to generic types needed by chore/add-lint-to-ci